### PR TITLE
Adds deactivate

### DIFF
--- a/DID_CCF.md
+++ b/DID_CCF.md
@@ -100,7 +100,11 @@ Supported ECDSA curves (curve):
 ```
 
 ### Deactivate
-Not currently supported.
+All authenticated members of the consortium can deactivate an identifier that is under their control by calling the **identifiers/<did>/decativate** endpoint. This API checks that the member making the request is the owner of the identifier and if true, removes the identifier and all it's associated keys from the network.
+
+```
+./scurl.sh https://<host>/app/identifiers/<did>/deactivate --cacert <service_certificate>.pem --signing-key <member_private_key.pem> --signing-cert <member_certificate.pem> -H "content-type: application/json" -X PATCH
+```
 
 ## Security and Privacy Considerations
 Confidential Consortium Framework (CCF) is an open-source framework for building highly available stateful services that leverage centralized compute for ease of use and performance, while providing decentralized trust. It enables multiple parties to execute auditable compute over confidential data without trusting each other or a privileged operator.

--- a/app.json
+++ b/app.json
@@ -1,5 +1,64 @@
 {
   "endpoints": {
+    "/identifiers/create": {
+      "post": {
+        "js_module": "endpoints/identifier/create.js",
+        "js_function": "create",
+        "forwarding_required": "always",
+        "authn_policies": ["member_signature"],
+        "mode": "readwrite",
+        "openapi": {
+          "parameters": [
+            {
+              "name": "alg",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "RSASSA-PKCS1-v1_5",
+                  "ECDSA",
+                  "EdDSA"
+                ]
+              }
+            },
+            {
+              "name": "size",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "number"
+              }
+            },
+            {
+              "name": "curve",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "secp256r1",
+                  "secp256k1",
+                  "secp384r1",
+                  "curve25519"
+                ]
+              }
+            }
+          ],
+          "responses": {
+            "201": {
+              "description": "Created",
+              "content": {
+                "application/json": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/identifiers/{id}/resolve": {
       "get": {
         "js_module": "endpoints/identifier/resolve.js",
@@ -7,6 +66,78 @@
         "forwarding_required": "always",
         "authn_policies": [],
         "mode": "readonly",
+        "openapi": {
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "application/json": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "properties": {
+                      "error": {
+                        "description": "Error message",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "error"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Not Found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "properties": {
+                      "error": {
+                        "description": "Error message",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "error"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/identifiers/{id}/deactivate": {
+      "get": {
+        "js_module": "endpoints/identifier/deactivate.js",
+        "js_function": "deactivate",
+        "forwarding_required": "always",
+        "authn_policies": ["member_signature"],
+        "mode": "readwrite",
         "openapi": {
           "parameters": [
             {
@@ -209,65 +340,6 @@
                     "type": "object",
                     "additionalProperties": false
                   }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/identifiers/create": {
-      "post": {
-        "js_module": "endpoints/identifier/create.js",
-        "js_function": "create",
-        "forwarding_required": "always",
-        "authn_policies": ["member_signature"],
-        "mode": "readwrite",
-        "openapi": {
-          "parameters": [
-            {
-              "name": "alg",
-              "in": "query",
-              "required": false,
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "RSASSA-PKCS1-v1_5",
-                  "ECDSA",
-                  "EdDSA"
-                ]
-              }
-            },
-            {
-              "name": "size",
-              "in": "query",
-              "required": false,
-              "schema": {
-                "type": "number"
-              }
-            },
-            {
-              "name": "curve",
-              "in": "query",
-              "required": false,
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "secp256r1",
-                  "secp256k1",
-                  "secp384r1",
-                  "curve25519"
-                ]
-              }
-            }
-          ],
-          "responses": {
-            "201": {
-              "description": "Created",
-              "content": {
-                "application/json": {
-                  "type": "object",
-                  "additionalProperties": true
                 }
               }
             }

--- a/app.json
+++ b/app.json
@@ -132,7 +132,7 @@
       }
     },
     "/identifiers/{id}/deactivate": {
-      "get": {
+      "patch": {
         "js_module": "endpoints/identifier/deactivate.js",
         "js_function": "deactivate",
         "forwarding_required": "always",

--- a/src/all.ts
+++ b/src/all.ts
@@ -19,6 +19,7 @@ export * from './models/QueryStringParser';
 are referenced in the app.json file. */
 export * from './endpoints/identifier/create';
 export * from './endpoints/identifier/resolve';
+export * from './endpoints/identifier/deactivate';
 export * from './endpoints/identifier/signature/sign';
 export * from './endpoints/identifier/signature/verify';
 export * from './endpoints/identifier/keys/list';

--- a/src/endpoints/identifier/create.ts
+++ b/src/endpoints/identifier/create.ts
@@ -13,9 +13,9 @@ import { QueryStringParser } from '../../models/QueryStringParser';
 import { KeyPairCreator } from '../../models/KeyPairCreator';
 
 /**
- * Creates a new decentralized identifier
- * @param request
- * @returns
+ * Creates a new decentralized identifier in the scope of the member.
+ * @param {ccfapp.Request} request containing the CCF request context.
+ * @returns HTTP 201 Created and the {@link ControllerDocument} for the newly created identifier.
  */
 export function create (request: ccfapp.Request): ccfapp.Response {
   // Decentralized Identifiers (DIDs) are created in the scope

--- a/src/endpoints/identifier/deactivate.ts
+++ b/src/endpoints/identifier/deactivate.ts
@@ -1,0 +1,58 @@
+import * as ccfapp from '@microsoft/ccf-app';
+import MemberIdentifierKeys from '../../models/MemberIdentifierKeys';
+
+/**
+ * Deactivates the specified decentralized identifier.
+ * @param {ccfapp.Request} request containing the CCF request context.
+ * @returns HTTP 200 OK on successful deactivation of the decentralized identifier.
+ */
+export function deactivate (request: ccfapp.Request): ccfapp.Response<any> {
+    // Decentralized Identifiers (DIDs) are created in the scope
+    // of a network member. Members are not limited in the number
+    // of identifiers they can create.
+    const memberId = <ccfapp.MemberSignatureAuthnIdentity>request.caller;
+    const controllerIdentifier = request.params.id;
+
+    // Check an identifier has been provided and
+    // if not return 400 Bad Request
+    if (!controllerIdentifier) {
+        return {
+        statusCode: 400,
+        body: {
+            error: 'A controller identifier must be specified.',
+        },
+        };
+    }
+
+    // Try read the identifier from the store
+    const identifierStore = ccfapp.typedKv('member_identifier_store', ccfapp.string, ccfapp.json<MemberIdentifierKeys>());
+    const memberIdentifierKeys: MemberIdentifierKeys =  <MemberIdentifierKeys>identifierStore.get(controllerIdentifier);
+
+    if (!memberIdentifierKeys) {
+        return {
+        statusCode: 404,
+        body: {
+            error: `Specified identifier '${controllerIdentifier}' not found on the network.`,
+        },
+        };
+    }
+
+    // Check that the member is the owner of the
+    // identifier.
+    if (memberIdentifierKeys.memberId !== memberId.id) {
+        return {
+        statusCode: 400,
+        body: {
+            error: `Specified identifier '${controllerIdentifier}' is not owned by the consortium member with ID '${memberId}'.`,
+        },
+        };
+    }
+
+    // Delete the controller identifier from the store. This removes
+    // the controller document and all associated keys from the store.
+    identifierStore.delete(controllerIdentifier);
+
+    return {
+        statusCode: 200
+    };
+}

--- a/src/endpoints/identifier/resolve.ts
+++ b/src/endpoints/identifier/resolve.ts
@@ -1,6 +1,11 @@
 import * as ccfapp from '@microsoft/ccf-app';
 import MemberIdentifierKeys from '../../models/MemberIdentifierKeys';
 
+/**
+ * Resolves the specified decentralized identifier.
+ * @param {ccfapp.Request} request containing the CCF request context.
+ * @returns HTTP 200 Created and the {@link ControllerDocument} for the identifier.
+ */
 export function resolve (request: ccfapp.Request): ccfapp.Response<any> {
   const controllerIdentifier = request.params.id;
 


### PR DESCRIPTION
In order to be compliant with W3C DID-Core specification and registration requirements, DID methods need to support a mechanism for deleting or deactivating a decentralized identifier. This PR adds a new endpoint that deactivates the specified identifier if the member making the request is the owner of the identifier.