### PR TITLE
Enable users to create/use DIDs on their own behalf

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
         "js_module": "endpoints/identifier/count.js",
         "js_function": "count",
         "forwarding_required": "never",
-        "authn_policies": ["member_signature"],
+        "authn_policies": ["member_signature", "user_signature"],
         "mode": "readonly",
         "openapi": {
           "responses": {
@@ -28,7 +28,7 @@
         "js_module": "endpoints/identifier/create.js",
         "js_function": "create",
         "forwarding_required": "always",
-        "authn_policies": ["jwt", "member_signature"],
+        "authn_policies": ["jwt", "member_signature", "user_signature"],
         "mode": "readwrite",
         "openapi": {
           "parameters": [
@@ -159,7 +159,7 @@
         "js_module": "endpoints/identifier/deactivate.js",
         "js_function": "deactivate",
         "forwarding_required": "always",
-        "authn_policies": ["jwt", "member_signature"],
+        "authn_policies": ["jwt", "member_signature", "user_signature"],
         "mode": "readwrite",
         "openapi": {
           "parameters": [
@@ -231,7 +231,7 @@
         "js_module": "endpoints/identifier/signature/sign.js",
         "js_function": "sign",
         "forwarding_required": "never",
-        "authn_policies": ["jwt", "member_signature"],
+        "authn_policies": ["jwt", "member_signature", "user_signature"],
         "mode": "readonly",
         "openapi": {
           "parameters": [
@@ -303,7 +303,7 @@
         "js_module": "endpoints/identifier/signature/verify.js",
         "js_function": "verify",
         "forwarding_required": "never",
-        "authn_policies": ["jwt", "member_signature"],
+        "authn_policies": ["jwt", "member_signature", "user_signature"],
         "mode": "readonly",
         "openapi": {
           "parameters": [
@@ -375,7 +375,7 @@
         "js_module": "endpoints/identifier/services/add.js",
         "js_function": "add",
         "forwarding_required": "always",
-        "authn_policies": ["jwt", "member_signature"],
+        "authn_policies": ["jwt", "member_signature", "user_signature"],
         "mode": "readonly",
         "openapi": {
           "parameters": [
@@ -447,7 +447,7 @@
         "js_module": "endpoints/identifier/services/remove.js",
         "js_function": "remove",
         "forwarding_required": "always",
-        "authn_policies": ["jwt", "member_signature"],
+        "authn_policies": ["jwt", "member_signature", "user_signature"],
         "mode": "readonly",
         "openapi": {
           "parameters": [
@@ -519,7 +519,7 @@
         "js_module": "endpoints/identifier/keys/list.js",
         "js_function": "list",
         "forwarding_required": "never",
-        "authn_policies": ["jwt", "member_signature"],
+        "authn_policies": ["jwt", "member_signature", "user_signature"],
         "mode": "readonly",
         "openapi": {
           "parameters": [
@@ -551,7 +551,7 @@
         "js_module": "endpoints/identifier/keys/roll.js",
         "js_function": "roll",
         "forwarding_required": "always",
-        "authn_policies": ["jwt", "member_signature"],
+        "authn_policies": ["jwt", "member_signature", "user_signature"],
         "mode": "readwrite",
         "openapi": {
           "parameters": [
@@ -618,7 +618,7 @@
         "js_module": "endpoints/identifier/keys/revoke.js",
         "js_function": "revoke",
         "forwarding_required": "always",
-        "authn_policies": ["jwt", "member_signature"],
+        "authn_policies": ["jwt", "member_signature", "user_signature"],
         "mode": "readwrite",
         "openapi": {
           "parameters": [
@@ -658,7 +658,7 @@
         "js_module": "endpoints/identifier/keys/exportPrivate.js",
         "js_function": "exportPrivate",
         "forwarding_required": "never",
-        "authn_policies": ["jwt", "member_signature"],
+        "authn_policies": ["jwt", "member_signature", "user_signature"],
         "mode": "readonly",
         "openapi": {
           "parameters": [

--- a/build_proposal.js
+++ b/build_proposal.js
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
-import { readdirSync, statSync, readFileSync, writeFileSync } from "fs";
+import { readdirSync, statSync, readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
 
 const args = process.argv.slice(2);
@@ -22,6 +22,10 @@ const getAllFiles = function (dirPath, arrayOfFiles) {
 };
 
 const rootDir = args[0];
+if (!existsSync(rootDir)){
+  mkdirSync(rootDir, { recursive: true });
+}
+
 const bundlePath = "dist/bundle.json";
 const bundle = JSON.parse(readFileSync(bundlePath, "utf-8"));
 

--- a/src/endpoints/identifier/create.ts
+++ b/src/endpoints/identifier/create.ts
@@ -82,16 +82,17 @@ export function create (request: Request): Response {
   // an on behalf of request, set both the `controller`
   // and `controllerDelegate`to the authenticated identity
   // identifier.
+  const controller = onBehalfOf || authenticatedIdentity.identifier;
   new IdentifierStore().addOrUpdate(
     <Identifier> {
       id: publicKeyDigestBase64Url,
-      controller: onBehalfOf || authenticatedIdentity.identifier,
+      controller,
       controllerDocument,
       keyPairs: [signingKeyPair, encryptionKeyPair],
       controllerDelegate: authenticatedIdentity.identifier,
     });
 
-  console.log(`Identifier '${identifierId}' created for member '${authenticatedIdentity.identifier}'.`);
+  console.log(`Identifier '${identifierId}' created for '${controller}'.`);
 
   // Return 201 and the controller document representing the newly created identifier.
   return {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the Code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them. 
-->
This PR fixes #31, enabling users to create/use DIDs on their own behalf by adding `user_signature` as an accepted authentication policy.

To test, install the app and invoke the `create`, `sign` and `verify` endpoints with a certificate/private key for a user.