### PR TITLE
Add support for arbitrary, member-specified domains for did:ccf DIDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /utils
 /node_modules
 /dist
+/.vscode
 package-lock.json

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,6 +3,7 @@
 
 // Export errors used by the endpoints
 export * from './errors/AuthenticatedRequestError';
+export * from './errors/DomainNotFound';
 export * from './errors/IdentifierNotFound';
 export * from './errors/IdentifierNotProvided';
 export * from './errors/InvalidController';

--- a/src/errors/DomainNotFound.ts
+++ b/src/errors/DomainNotFound.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+import { AuthenticatedIdentity } from '../models';
+import { AuthenticatedRequestError } from './AuthenticatedRequestError';
+import { ErrorCodes } from './ErrorCodes';
+
+/**
+ * Error for indicating that a domain was not found.
+ */
+export class DomainNotFound extends AuthenticatedRequestError {
+  /**
+   * Constructs a new instance of the {@link DomainNotFound} class.
+   * @param {string} name of a domain that could not be found.
+   * @param {AuthenticatedIdentity} authenticatedIdentity making the request.
+   */
+  constructor (public name: string, public authenticatedIdentity: AuthenticatedIdentity) {
+    super(
+      authenticatedIdentity,
+      ErrorCodes.DomainNotFound,
+      `The domain '${name}' was not found.`,
+      404);
+  }
+}

--- a/src/errors/ErrorCodes.ts
+++ b/src/errors/ErrorCodes.ts
@@ -72,4 +72,9 @@ export enum ErrorCodes {
    * request.
    */
   SignatureNotProvided = 'request.signature_not_provided',
+
+  /**
+   * Indicates that a domain has not been registered.
+   */
+  DomainNotFound = 'request.domain_not_found',
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -4,6 +4,7 @@
 // Export models used by the endpoints
 export * from './models/AuthenticatedIdentity';
 export * from './models/ControllerDocument';
+export * from './models/Domain';
 export * from './models/EcdsaCurve';
 export * from './models/EcdsaKeyPair';
 export * from './models/EddsaCurve';

--- a/src/models/Domain.ts
+++ b/src/models/Domain.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+import {
+  json as jsonConverter,
+  string as stringConverter,
+  typedKv as keyStore,
+} from '@microsoft/ccf-app';
+
+/**
+ * Encapsulates a domain
+ */
+export class Domain {
+  /**
+   * Constructs a new instance of the class.
+   * @param name the domain's name (e.g. example.com)
+   */
+  constructor (public name: string) {
+  }
+
+  /**
+   * Returns true if a domain with the given name has been registered
+   * @param name the name of a domain
+   */
+  public static isRegistered (name: string) : boolean {
+    const normalized = name.trim().toLowerCase();
+    const kv = keyStore('public:ccf.gov.did.domains', stringConverter, jsonConverter<Domain>());
+    return kv.has(normalized);
+  }
+}

--- a/src/models/RequestParameters.ts
+++ b/src/models/RequestParameters.ts
@@ -42,4 +42,9 @@ export enum RequestParameters {
      * Service identifier path parameter.
      */
     ServiceIdentifier = 'service',
+
+    /**
+     * Domain identifier path parameter.
+     */
+    Domain = 'domain',
 }


### PR DESCRIPTION
This PR extends `did:ccf` by enabling members to specify domains in which DIDs may be registered.