### PR TITLE
Converts method identifiers to DID relative URIs

### DIFF
--- a/src/endpoints/identifier/keys/roll.ts
+++ b/src/endpoints/identifier/keys/roll.ts
@@ -105,7 +105,7 @@ export function roll (request: Request): Response {
       VerificationMethodRelationship.KeyAgreement;
 
     controllerDocument.addVerificationMethod({
-      id: newKey.id,
+      id: `#${newKey.id}`,
       controller: identifier.controllerDocument.id,
       type: VerificationMethodType.JsonWebKey2020,
       publicKeyJwk: newKey.asJwk(false),

--- a/src/models/ControllerDocument.ts
+++ b/src/models/ControllerDocument.ts
@@ -38,6 +38,9 @@ export class ControllerDocument {
       'https://www.w3.org/ns/did/v1',
       'https://w3id.org/security/suites/jws-2020/v1',
       {
+        '@base': id,
+      },
+      {
         '@vocab': 'https://github.com/microsoft/did-ccf/blob/main/DID_CCF.md#',
       },
     ];

--- a/src/models/IdentifierCreator.ts
+++ b/src/models/IdentifierCreator.ts
@@ -31,7 +31,7 @@ export class IdentifierCreator {
 
     // Add the signing key
     controllerDocument.addVerificationMethod({
-      id: `${did}#${signingKeyPair.id}`,
+      id: `#${signingKeyPair.id}`,
       controller: did,
       type: VerificationMethodType.JsonWebKey2020,
       publicKeyJwk: signingKeyPair.asJwk(false),
@@ -39,7 +39,7 @@ export class IdentifierCreator {
 
     // Add the encryption key
     controllerDocument.addVerificationMethod({
-      id: `${did}#${encryptionKeyPair.id}`,
+      id: `#${encryptionKeyPair.id}`,
       controller: did,
       type: VerificationMethodType.JsonWebKey2020,
       publicKeyJwk: encryptionKeyPair.asJwk(false),

--- a/tests/unit/models/ControllerDocument.js
+++ b/tests/unit/models/ControllerDocument.js
@@ -6,7 +6,7 @@ import { VerificationMethodRelationship } from '../../../dist/src/models/Verific
 
 import { expect } from 'chai';
 
-const EXPECTED_CONTEXT = '"@context":["https://www.w3.org/ns/did/v1","https://w3id.org/security/suites/jws-2020/v1",{"@vocab":"https://github.com/microsoft/did-ccf/blob/main/DID_CCF.md#"}]';
+const EXPECTED_CONTEXT = '"@context":["https://www.w3.org/ns/did/v1","https://w3id.org/security/suites/jws-2020/v1",{"@base":"test_identifier"},{"@vocab":"https://github.com/microsoft/did-ccf/blob/main/DID_CCF.md#"}]';
 
 describe ('ControllerDocument', () => {
     it ('should serialize to JSON with @context', () =>{
@@ -19,33 +19,33 @@ describe ('ControllerDocument', () => {
         it ('should add verification method and serialize to JSON', () =>{
             const controllerDocument = new ControllerDocument('test_identifier');
             const verificationMethod = {
-                id: "method_identifier",
+                id: "#method_identifier",
                 controller: "test_identifier",
                 type: VerificationMethodType.JsonWebKey2020,
                 publicKeyJwk: {}
             };
             controllerDocument.addVerificationMethod(verificationMethod);
             const json = JSON.stringify(controllerDocument);
-            expect(json).to.equal(`{"id":"test_identifier","verificationMethod":[{"id":"method_identifier","controller":"test_identifier","type":"JsonWebKey2020","publicKeyJwk":{}}],${EXPECTED_CONTEXT}}`);
+            expect(json).to.equal(`{"id":"test_identifier","verificationMethod":[{"id":"#method_identifier","controller":"test_identifier","type":"JsonWebKey2020","publicKeyJwk":{}}],${EXPECTED_CONTEXT}}`);
         });
 
         it ('should add verification method plus relationship and serialize to JSON', () =>{
             const controllerDocument = new ControllerDocument('test_identifier');
             const verificationMethod = {
-                id: "method_identifier",
+                id: "#method_identifier",
                 controller: "test_identifier",
                 type: VerificationMethodType.JsonWebKey2020,
                 publicKeyJwk: {}
             };
             controllerDocument.addVerificationMethod(verificationMethod, [VerificationMethodRelationship.Authentication ] )
             const json = JSON.stringify(controllerDocument);
-            expect(json).to.equal(`{"id":"test_identifier","verificationMethod":[{"id":"method_identifier","controller":"test_identifier","type":"JsonWebKey2020","publicKeyJwk":{}}],${EXPECTED_CONTEXT},"authentication":["method_identifier"]}`);
+            expect(json).to.equal(`{"id":"test_identifier","verificationMethod":[{"id":"#method_identifier","controller":"test_identifier","type":"JsonWebKey2020","publicKeyJwk":{}}],${EXPECTED_CONTEXT},"authentication":["#method_identifier"]}`);
         });
 
         it ('should add verification relationships when provided', () =>{
             const controllerDocument = new ControllerDocument('test_identifier');
             const verificationMethod = {
-                id: "method_identifier",
+                id: "#method_identifier",
                 controller: "test_identifier",
                 type: VerificationMethodType.JsonWebKey2020,
                 publicKeyJwk: {}


### PR DESCRIPTION
This PR addresses #39:

- Adds @base property to the controller document
- Prefixes **verificationMethod** identifiers with the DID relative fragment marker *'#'* during the creation and rolling of verification methods.
- Updates unit tests